### PR TITLE
Initialize App when creating new server

### DIFF
--- a/internal/api/httpserver.go
+++ b/internal/api/httpserver.go
@@ -21,7 +21,7 @@ type Server struct {
 
 // New creates a new Server, initializes it and returns it.
 func NewHttpServer(p ProcessFunc) *Server {
-	api := &Server{processFunc: p}
+	api := &Server{processFunc: p, App: app.New()}
 	api.Use(logger.New())
 	api.Post("/listen", api.requestHandler)
 	return api

--- a/internal/api/httpserver_test.go
+++ b/internal/api/httpserver_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"io"
+	"testing"
+)
+
+func TestNewHttpServer(t *testing.T) {
+	fn := func(r io.ReadCloser) error {
+		return nil
+	}
+
+	NewHttpServer(fn)
+}


### PR DESCRIPTION
While trying to run [connect-kafka](https://github.com/segment-integrations/connect-kafka) I was getting a panic from within the `connect` package.

Looks like `App` needs to be initialized:

```go
api := &Server{processFunc: p, App: app.New()}
```

Otherwise it will panic when trying to use the Log middleware:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1236fef]

goroutine 5 [running]:
testing.tRunner.func1(0xc4201080f0)
	/usr/local/Cellar/go/1.9.1/libexec/src/testing/testing.go:711 +0x2d2
panic(0x128ff00, 0x145caf0)
	/usr/local/Cellar/go/1.9.1/libexec/src/runtime/panic.go:491 +0x283
github.com/gohttp/app.(*App).Use(0x0, 0xc42000e038, 0x1, 0x1)
	/Users/harlow/code/go/src/github.com/gohttp/app/app.go:28 +0x13f
github.com/harlow/connect/internal/api.NewHttpServer(0x12f6160, 0x156f71)
	/Users/harlow/code/go/src/github.com/harlow/connect/internal/api/httpserver.go:25 +0xba
github.com/harlow/connect/internal/api.TestNewHttpServer(0xc4201080f0)
	/Users/harlow/code/go/src/github.com/harlow/connect/internal/api/httpserver_test.go:13 +0x2d
testing.tRunner(0xc4201080f0, 0x12f6168)
	/usr/local/Cellar/go/1.9.1/libexec/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.9.1/libexec/src/testing/testing.go:789 +0x2de
exit status 2
```